### PR TITLE
Fix 54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.ini
 mergin
 .coverage
 htmlcov
+.vscode
+.env

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ To run automatic tests:
     export TEST_MERGIN_URL=<url>                # testing server
     export TEST_API_USERNAME=<username>
     export TEST_API_PASSWORD=<pwd>
+    export TEST_API_WORKSPACE=<workspace>
     pytest-3 test/
 
 

--- a/dbsync.py
+++ b/dbsync.py
@@ -236,6 +236,7 @@ def _set_db_project_comment(conn, schema, project_name, version, project_id=None
 def _get_db_project_comment(conn, schema):
     """ Get Mergin Maps project name and its current version in db schema"""
     cur = conn.cursor()
+    schema = _add_quotes_to_schema_name(schema)
     cur.execute("SELECT obj_description(%s::regnamespace, 'pg_namespace')", (schema, ))
     res = cur.fetchone()[0]
     try:

--- a/dbsync.py
+++ b/dbsync.py
@@ -34,6 +34,12 @@ class DbSyncError(Exception):
     pass
 
 
+def _add_quotes_to_schema_name(schema: str) -> str:
+    if any(ele.isupper() for ele in schema):
+        schema = f'"{schema}"'
+    return schema
+
+
 def _tables_list_to_string(tables):
     return ";".join(tables)
 

--- a/dbsync.py
+++ b/dbsync.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import random
 import uuid
+import re
 
 import psycopg2
 from itertools import chain
@@ -35,7 +36,9 @@ class DbSyncError(Exception):
 
 
 def _add_quotes_to_schema_name(schema: str) -> str:
-    if any(ele.isupper() for ele in schema):
+    matches = re.findall(r"[^a-z0-9_]", schema)
+    if len(matches) != 0:
+        schema = schema.replace("\"", "\"\"")
         schema = f'"{schema}"'
     return schema
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -97,7 +97,8 @@ def init_sync_from_geopackage(mc, project_name, source_gpkg_path, ignored_tables
 
     dbsync_init(mc, from_gpkg=True)
 
-@pytest.mark.parametrize("project_name", ['test_init', 'Test_Init'])
+
+@pytest.mark.parametrize("project_name", ['test_init_1', 'Test_Init_2', "Test 3", "Test-4"])
 def test_init_from_gpkg(mc: MerginClient, project_name: str):
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     project_dir = os.path.join(TMP_DIR, project_name + '_work')
@@ -196,7 +197,7 @@ def test_init_from_gpkg(mc: MerginClient, project_name: str):
     assert "There are pending changes in the local directory - that should never happen" in str(err.value)
 
 
-@pytest.mark.parametrize("project_name", ['test_init', 'Test_init'])
+@pytest.mark.parametrize("project_name", ['test_init_incomplete_dir_1', 'Test_Init_Incomplete_Dir_2'])
 def test_init_from_gpkg_with_incomplete_dir(mc: MerginClient, project_name: str):
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     init_project_dir = os.path.join(TMP_DIR, project_name + '_dbsync', project_name)
@@ -209,7 +210,7 @@ def test_init_from_gpkg_with_incomplete_dir(mc: MerginClient, project_name: str)
     assert os.listdir(init_project_dir) == ['test_sync.gpkg', '.mergin']
 
 
-@pytest.mark.parametrize("project_name", ['test_sync_pull', 'Test_Sync_Pull'])
+@pytest.mark.parametrize("project_name", ['test_sync_pull_1', 'Test_Sync_Pull_2'])
 def test_basic_pull(mc: MerginClient, project_name: str):
     """
     Test initialization and one pull from Mergin Maps to DB
@@ -249,7 +250,7 @@ def test_basic_pull(mc: MerginClient, project_name: str):
     dbsync_status(mc)
 
 
-@pytest.mark.parametrize("project_name", ['test_sync_push', 'Test_Sync_Push'])
+@pytest.mark.parametrize("project_name", ['test_sync_push_1', 'Test_Sync_Push_2'])
 def test_basic_push(mc: MerginClient, project_name: str):
     """ Initialize a project and test push of a new row from PostgreSQL to Mergin Maps"""
     db_schema_main = project_name + "_main"
@@ -291,7 +292,7 @@ def test_basic_push(mc: MerginClient, project_name: str):
     dbsync_status(mc)
 
 
-@pytest.mark.parametrize("project_name", ['test_sync_both', 'Test_Sync_Both'])
+@pytest.mark.parametrize("project_name", ['test_sync_both_1', 'Test_Sync_Both_2'])
 def test_basic_both(mc: MerginClient, project_name: str):
     """ Initializes a sync project and does both a change in Mergin Maps and in the database,
     and lets DB sync handle it: changes in PostgreSQL need to be rebased on top of
@@ -349,7 +350,7 @@ def test_basic_both(mc: MerginClient, project_name: str):
     dbsync_status(mc)
 
 
-@pytest.mark.parametrize("project_name", ['test_init_skip', 'Test_Init_Skip'])
+@pytest.mark.parametrize("project_name", ['test_init_skip_1', 'Test_Init_Skip_2'])
 def test_init_with_skip(mc: MerginClient, project_name: str):
 
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base_2tables.gpkg')
@@ -386,7 +387,7 @@ def test_init_with_skip(mc: MerginClient, project_name: str):
     assert cur.fetchone()[0] == 4
 
 
-@pytest.mark.parametrize("project_name", ['test_local_changes', 'Test_Local_Changes'])
+@pytest.mark.parametrize("project_name", ['test_local_changes_1', 'Test_Local_Changes_2'])
 def test_with_local_changes(mc: MerginClient, project_name: str):
 
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
@@ -418,7 +419,7 @@ def test_with_local_changes(mc: MerginClient, project_name: str):
     assert any(local_changes.values()) is False
     dbsync_status(mc)
 
-@pytest.mark.parametrize("project_name", ['test_recreated_project_ids', 'Test_Recreated_Project_Ids'])
+@pytest.mark.parametrize("project_name", ['test_recreated_project_ids_1', 'Test_Recreated_Project_Ids_2'])
 def test_recreated_project_ids(mc: MerginClient, project_name: str):
 
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -17,6 +17,7 @@ DB_CONNINFO = os.environ.get('TEST_DB_CONNINFO')
 SERVER_URL = os.environ.get('TEST_MERGIN_URL')
 API_USER = os.environ.get('TEST_API_USERNAME')
 USER_PWD = os.environ.get('TEST_API_PASSWORD')
+WORKSPACE = os.environ.get('TEST_API_WORKSPACE')
 TMP_DIR = tempfile.gettempdir()
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_data')
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -97,7 +97,7 @@ def init_sync_from_geopackage(mc, project_name, source_gpkg_path, ignored_tables
     dbsync_init(mc, from_gpkg=True)
 
 
-@pytest.mark.parametrize("project_name", ['test_init', 'Test_init'])
+@pytest.mark.parametrize("project_name", ['test_init', 'Test_Init'])
 def test_init_from_gpkg(mc: MerginClient, project_name: str):
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     project_dir = os.path.join(TMP_DIR, project_name + '_work')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -98,8 +98,8 @@ def init_sync_from_geopackage(mc, project_name, source_gpkg_path, ignored_tables
     dbsync_init(mc, from_gpkg=True)
 
 
-@pytest.mark.parametrize("project_name", ['test_init_1', 'Test_Init_2', "Test 3", "Test-4"])
-def test_init_from_gpkg(mc: MerginClient, project_name: str):
+def test_init_from_gpkg(mc: MerginClient):
+    project_name = "test_init"
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     project_dir = os.path.join(TMP_DIR, project_name + '_work')
     db_schema_main = project_name + '_main'
@@ -197,8 +197,8 @@ def test_init_from_gpkg(mc: MerginClient, project_name: str):
     assert "There are pending changes in the local directory - that should never happen" in str(err.value)
 
 
-@pytest.mark.parametrize("project_name", ['test_init_incomplete_dir_1', 'Test_Init_Incomplete_Dir_2'])
-def test_init_from_gpkg_with_incomplete_dir(mc: MerginClient, project_name: str):
+def test_init_from_gpkg_with_incomplete_dir(mc: MerginClient):
+    project_name = "test_init_incomplete_dir"
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     init_project_dir = os.path.join(TMP_DIR, project_name + '_dbsync', project_name)
     init_sync_from_geopackage(mc, project_name, source_gpkg_path)
@@ -210,14 +210,14 @@ def test_init_from_gpkg_with_incomplete_dir(mc: MerginClient, project_name: str)
     assert os.listdir(init_project_dir) == ['test_sync.gpkg', '.mergin']
 
 
-@pytest.mark.parametrize("project_name", ['test_sync_pull_1', 'Test_Sync_Pull_2'])
-def test_basic_pull(mc: MerginClient, project_name: str):
+def test_basic_pull(mc: MerginClient):
     """
     Test initialization and one pull from Mergin Maps to DB
     1. create a Mergin Maps project using py-client with a testing gpkg
     2. run init, check that everything is fine
     3. make change in gpkg (copy new version), check everything is fine
     """
+    project_name = 'test_sync_pull'
     db_schema_main = project_name + "_main"
 
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
@@ -250,9 +250,9 @@ def test_basic_pull(mc: MerginClient, project_name: str):
     dbsync_status(mc)
 
 
-@pytest.mark.parametrize("project_name", ['test_sync_push_1', 'Test_Sync_Push_2'])
-def test_basic_push(mc: MerginClient, project_name: str):
+def test_basic_push(mc: MerginClient):
     """ Initialize a project and test push of a new row from PostgreSQL to Mergin Maps"""
+    project_name = "test_sync_push"
     db_schema_main = project_name + "_main"
 
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
@@ -292,12 +292,12 @@ def test_basic_push(mc: MerginClient, project_name: str):
     dbsync_status(mc)
 
 
-@pytest.mark.parametrize("project_name", ['test_sync_both_1', 'Test_Sync_Both_2'])
-def test_basic_both(mc: MerginClient, project_name: str):
+def test_basic_both(mc: MerginClient):
     """ Initializes a sync project and does both a change in Mergin Maps and in the database,
     and lets DB sync handle it: changes in PostgreSQL need to be rebased on top of
     changes in Mergin Maps server.
     """
+    project_name = "test_sync_both"
     db_schema_main = project_name + "_main"
     db_schema_base = project_name + "_base"
 
@@ -350,9 +350,8 @@ def test_basic_both(mc: MerginClient, project_name: str):
     dbsync_status(mc)
 
 
-@pytest.mark.parametrize("project_name", ['test_init_skip_1', 'Test_Init_Skip_2'])
-def test_init_with_skip(mc: MerginClient, project_name: str):
-
+def test_init_with_skip(mc: MerginClient):
+    project_name = "test_init_skip"
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base_2tables.gpkg')
     project_dir = os.path.join(TMP_DIR, project_name + '_work')
     db_schema_main = project_name + '_main'
@@ -387,9 +386,8 @@ def test_init_with_skip(mc: MerginClient, project_name: str):
     assert cur.fetchone()[0] == 4
 
 
-@pytest.mark.parametrize("project_name", ['test_local_changes_1', 'Test_Local_Changes_2'])
-def test_with_local_changes(mc: MerginClient, project_name: str):
-
+def test_with_local_changes(mc: MerginClient):
+    project_name = "test_local_changes"
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     extra_files = [os.path.join(TEST_DATA_DIR, f) for f in ["note_1.txt", "note_3.txt", "modified_all.gpkg"]]
     dbsync_project_dir = os.path.join(TMP_DIR, project_name + '_dbsync',
@@ -419,9 +417,9 @@ def test_with_local_changes(mc: MerginClient, project_name: str):
     assert any(local_changes.values()) is False
     dbsync_status(mc)
 
-@pytest.mark.parametrize("project_name", ['test_recreated_project_ids_1', 'Test_Recreated_Project_Ids_2'])
-def test_recreated_project_ids(mc: MerginClient, project_name: str):
 
+def test_recreated_project_ids(mc: MerginClient):
+    project_name = "test_recreated_project_ids"
     source_gpkg_path = os.path.join(TEST_DATA_DIR, 'base.gpkg')
     project_dir = os.path.join(TMP_DIR, project_name + '_work')  # working directory
     full_project_name = WORKSPACE + "/" + project_name


### PR DESCRIPTION
Fixes #54 .

Contains also significant additions to tests. All the tests are run on two project names, all SQL queries in test should properly escape schema names.